### PR TITLE
bench: Fix cancellation

### DIFF
--- a/bench/isutrain/session.go
+++ b/bench/isutrain/session.go
@@ -70,7 +70,7 @@ func (sess *Session) newRequest(ctx context.Context, method, uri string, body io
 		return nil, err
 	}
 
-	req.WithContext(ctx)
+	req = req.WithContext(ctx)
 	req.Header.Add("User-Agent", config.UserAgent)
 
 	return req, nil


### PR DESCRIPTION
req.WithContext() の使い方にバグがあり、リクエストがコンテキストに
紐づいておらず、シナリオがキャンセルされていなかった。

メインスレッドで5秒待ってから予約キャンセルのチェックをしてるが、
負荷が増えると5秒たっても動いているシナリオがいて、予約キャンセル
直後のpaymentをチェックして critical error になってしまう。